### PR TITLE
fix: Demo Unhandled Exception:  Null check operator used on a null value Close #29

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,6 @@ void main() => runApp(new MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    ToastContext().init(context);
     return new MaterialApp(
       title: 'Flutter Demo',
       theme: new ThemeData(
@@ -26,6 +25,13 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyHomePage> {
+
+  @override
+  void initState() {
+    super.initState();
+    ToastContext().init(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(


### PR DESCRIPTION
[PROBLEM]

The [official demo](https://github.com/appdev/FlutterToast/blob/4654d39ec9cfced65e39dc93039d7da3f6b1ea3c/example/lib/main.dart#L9) will throw the error `Unhandled Exception: Null check operator used on a null value` when showing toast.

see: [Issue#29](https://github.com/appdev/FlutterToast/issues/29)

[REASON]
1. `Toast.show` need invoke `ToastView.createView` which need `overlayState` from its ancestor widget.
2. The [official demo](https://github.com/appdev/FlutterToast/blob/master/example/lib/main.dart) initial the `ToastContext` in `MyApp.build`, which ancestor element is `RenderObjectToWidgetElement -> StatelessElement
`，so `Overlay.of` can't find `overlayState`.
3. Meanwhile the `MaterialApp` already insert an `overlayState` for us

[SOLUTION]

Use the context of `MyHomePage` instead of `MyApp`.

[TEST]

Work with Flutter (Channel stable, 2.10.5, on Microsoft Windows [Version 10.0.19043.1766], locale en-US)

![image](https://user-images.githubusercontent.com/18367427/175806843-094e1c28-8613-433a-8c49-15fa1f291af3.png)
